### PR TITLE
ESHOP-272: Allow direct credit card payment

### DIFF
--- a/paypal/express/facade.py
+++ b/paypal/express/facade.py
@@ -24,7 +24,7 @@ def _get_payment_action():
 
 def get_paypal_url(basket, shipping_methods, user=None, shipping_address=None,
                    shipping_method=None, host=None, scheme=None,
-                   paypal_params=None):
+                   paypal_params=None, ccard=False):
     """
     Return the URL for a PayPal Express transaction.
 
@@ -83,7 +83,8 @@ def get_paypal_url(basket, shipping_methods, user=None, shipping_address=None,
                    user=user,
                    user_address=address,
                    no_shipping=no_shipping,
-                   paypal_params=paypal_params)
+                   paypal_params=paypal_params,
+                   ccard=ccard)
 
 
 def fetch_transaction_details(token):

--- a/paypal/express/gateway.py
+++ b/paypal/express/gateway.py
@@ -115,7 +115,7 @@ def _fetch_response(method, extra_params):
 
 def set_txn(basket, shipping_methods, currency, return_url, cancel_url, update_url=None,
             action=SALE, user=None, user_address=None, shipping_method=None,
-            shipping_address=None, no_shipping=False, paypal_params=None):
+            shipping_address=None, no_shipping=False, paypal_params=None, ccard=False):
     """
     Register the transaction with PayPal to get a token which we use in the
     redirect URL.  This is the 'SetExpressCheckout' from their documentation.
@@ -347,11 +347,18 @@ def set_txn(basket, shipping_methods, currency, return_url, cancel_url, update_u
 
     # Construct return URL
     if getattr(settings, 'PAYPAL_SANDBOX_MODE', True):
-        url = 'https://www.sandbox.paypal.com/webscr'
+        url = 'https://www.sandbox.paypal.com/'
     else:
-        url = 'https://www.paypal.com/webscr'
-    params = (('cmd', '_express-checkout'),
-              ('token', txn.token),)
+        url = 'https://www.paypal.com/'
+
+    if not ccard:
+        url += 'webscr'
+        params = (('cmd', '_express-checkout'),
+                  ('token', txn.token),)
+    else:
+        url += 'webapps/xoonboarding'
+        params = (('token', txn.token),)
+
     return '%s?%s' % (url, urlencode(params))
 
 

--- a/paypal/express/views.py
+++ b/paypal/express/views.py
@@ -61,6 +61,9 @@ class RedirectView(CheckoutSessionMixin, RedirectView):
     # basket page but True when redirecting from checkout.
     as_payment_method = False
 
+    # If True redirect directly to credit card payment
+    ccard = False
+
     def get_redirect_url(self, **kwargs):
         try:
             basket = self.build_submission()['basket']
@@ -140,6 +143,7 @@ class RedirectView(CheckoutSessionMixin, RedirectView):
             params['user'] = user
 
         params['paypal_params'] = self._get_paypal_params()
+        params['ccard'] = self.ccard
 
         return get_paypal_url(**params)
 


### PR DESCRIPTION
Redirect directly to the credit card page of paypal instead of the classic paypal login page